### PR TITLE
[Feat] JPA 쿼리 카운터 구현

### DIFF
--- a/src/main/java/idorm/idormServer/common/config/FirebaseConfig.java
+++ b/src/main/java/idorm/idormServer/common/config/FirebaseConfig.java
@@ -1,4 +1,4 @@
-package idorm.idormServer.config;
+package idorm.idormServer.common.config;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;

--- a/src/main/java/idorm/idormServer/common/config/JpaAuditingConfig.java
+++ b/src/main/java/idorm/idormServer/common/config/JpaAuditingConfig.java
@@ -1,4 +1,4 @@
-package idorm.idormServer.config;
+package idorm.idormServer.common.config;
 
 import javax.persistence.EntityManager;
 

--- a/src/main/java/idorm/idormServer/common/config/S3Config.java
+++ b/src/main/java/idorm/idormServer/common/config/S3Config.java
@@ -1,4 +1,4 @@
-package idorm.idormServer.config;
+package idorm.idormServer.common.config;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;

--- a/src/main/java/idorm/idormServer/common/config/SchedulingConfig.java
+++ b/src/main/java/idorm/idormServer/common/config/SchedulingConfig.java
@@ -1,4 +1,4 @@
-package idorm.idormServer.config;
+package idorm.idormServer.common.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;

--- a/src/main/java/idorm/idormServer/common/config/SwaggerConfig.java
+++ b/src/main/java/idorm/idormServer/common/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package idorm.idormServer.config;
+package idorm.idormServer.common.config;
 
 import org.apache.http.HttpHeaders;
 import org.springdoc.core.SpringDocUtils;

--- a/src/main/java/idorm/idormServer/common/config/TimeConfig.java
+++ b/src/main/java/idorm/idormServer/common/config/TimeConfig.java
@@ -1,4 +1,4 @@
-package idorm.idormServer.config;
+package idorm.idormServer.common.config;
 
 import java.time.Clock;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/idorm/idormServer/common/config/WebMvcConfig.java
+++ b/src/main/java/idorm/idormServer/common/config/WebMvcConfig.java
@@ -1,0 +1,39 @@
+package idorm.idormServer.common.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import idorm.idormServer.auth.adapter.in.web.AuthInterceptor;
+import idorm.idormServer.auth.adapter.in.web.AuthResponseArgumentResolver;
+import idorm.idormServer.auth.application.port.in.JwtTokenUseCase;
+import lombok.RequiredArgsConstructor;
+
+@Profile("!local")
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+	private final AuthInterceptor authInterceptor;
+	private final JwtTokenUseCase jwtTokenUseCase;
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(authInterceptor)
+			.addPathPatterns("/**")
+			.excludePathPatterns("/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**")
+			.excludePathPatterns("/api/v1/email/**")
+			.excludePathPatterns("/api/v1/signup", "/api/v1/signin", "/api/v1/refresh")
+			.excludePathPatterns("/api/v1/members/me/password")
+			.excludePathPatterns("/test/**");
+	}
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(new AuthResponseArgumentResolver(jwtTokenUseCase));
+	}
+}

--- a/src/main/java/idorm/idormServer/common/config/WebMvcLocalConfig.java
+++ b/src/main/java/idorm/idormServer/common/config/WebMvcLocalConfig.java
@@ -1,8 +1,9 @@
-package idorm.idormServer.config;
+package idorm.idormServer.common.config;
 
 import java.util.List;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -10,24 +11,32 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import idorm.idormServer.auth.adapter.in.web.AuthInterceptor;
 import idorm.idormServer.auth.adapter.in.web.AuthResponseArgumentResolver;
 import idorm.idormServer.auth.application.port.in.JwtTokenUseCase;
+import idorm.idormServer.common.performance.QueryCountInterceptor;
 import lombok.RequiredArgsConstructor;
 
+@Profile("local")
 @Configuration
 @RequiredArgsConstructor
-public class WebMvcConfig implements WebMvcConfigurer {
+public class WebMvcLocalConfig implements WebMvcConfigurer {
 
+	private final QueryCountInterceptor queryCountInterceptor;
 	private final AuthInterceptor authInterceptor;
 	private final JwtTokenUseCase jwtTokenUseCase;
 
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
 		registry.addInterceptor(authInterceptor)
+			.order(1)
 			.addPathPatterns("/**")
 			.excludePathPatterns("/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**")
 			.excludePathPatterns("/api/v1/email/**")
 			.excludePathPatterns("/api/v1/signup", "/api/v1/signin", "/api/v1/refresh")
 			.excludePathPatterns("/api/v1/members/me/password")
 			.excludePathPatterns("/test/**");
+
+		registry.addInterceptor(queryCountInterceptor)
+			.order(2)
+			.addPathPatterns("/**");
 	}
 
 	@Override

--- a/src/main/java/idorm/idormServer/common/config/WebSecurityConfig.java
+++ b/src/main/java/idorm/idormServer/common/config/WebSecurityConfig.java
@@ -1,4 +1,4 @@
-package idorm.idormServer.config;
+package idorm.idormServer.common.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;

--- a/src/main/java/idorm/idormServer/common/logging/ErrorLoggingAdvice.java
+++ b/src/main/java/idorm/idormServer/common/logging/ErrorLoggingAdvice.java
@@ -1,4 +1,4 @@
-package idorm.idormServer.common.aop;
+package idorm.idormServer.common.logging;
 
 import static org.springframework.http.HttpStatus.*;
 
@@ -23,10 +23,10 @@ import lombok.extern.slf4j.Slf4j;
 public class ErrorLoggingAdvice {
 
 	@Pointcut("execution(* idorm.idormServer..*(..))")
-	private void all() {
+	private void allPointcut() {
 	}
 
-	@AfterThrowing(value = "all()", throwing = "exception")
+	@AfterThrowing(value = "allPointcut()", throwing = "exception")
 	public void logAfterThrowing(JoinPoint joinPoint, BaseException exception) {
 		if (!exception.getCode().getStatus().equals(INTERNAL_SERVER_ERROR)) {
 			return;

--- a/src/main/java/idorm/idormServer/common/logging/ExecutionTimer.java
+++ b/src/main/java/idorm/idormServer/common/logging/ExecutionTimer.java
@@ -1,4 +1,4 @@
-package idorm.idormServer.common.aop;
+package idorm.idormServer.common.logging;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/idorm/idormServer/common/logging/LoggingAdvice.java
+++ b/src/main/java/idorm/idormServer/common/logging/LoggingAdvice.java
@@ -1,4 +1,4 @@
-package idorm.idormServer.common.aop;
+package idorm.idormServer.common.logging;
 
 import java.lang.reflect.Method;
 import java.util.Objects;
@@ -26,10 +26,10 @@ import lombok.extern.slf4j.Slf4j;
 public class LoggingAdvice {
 
 	@Pointcut("execution(* idorm.idormServer..*(..))")
-	private void all() {
+	private void allPointcut() {
 	}
 
-	@Pointcut("@annotation(idorm.idormServer.common.aop.ExecutionTimer)")
+	@Pointcut("@annotation(idorm.idormServer.common.logging.ExecutionTimer)")
 	private void executionTimer() {
 	}
 
@@ -49,7 +49,7 @@ public class LoggingAdvice {
 		log.info("실행 메서드: {}, 실행시간 = {}ms", methodName, totalTimeMillis);
 	}
 
-	@Before("all()")
+	@Before("allPointcut()")
 	public void preHandle(JoinPoint joinPoint) {
 		final MethodSignature signature = (MethodSignature)joinPoint.getSignature();
 		final Class className = signature.getDeclaringType();
@@ -71,7 +71,7 @@ public class LoggingAdvice {
 		log.info("[START] {} | {} {}", className.getSimpleName(), method.getName(), returnArgs);
 	}
 
-	@AfterReturning(value = "all()", returning = "result")
+	@AfterReturning(value = "allPointcut()", returning = "result")
 	public void afterHandle(JoinPoint joinPoint, Object result) {
 		MethodSignature signature = (MethodSignature)joinPoint.getSignature();
 		Class className = signature.getDeclaringType();
@@ -80,7 +80,7 @@ public class LoggingAdvice {
 		log.info("[SUCCESS] {} | {} | return = {}", className.getSimpleName(), method.getName(), result);
 	}
 
-	@AfterThrowing(value = "all()", throwing = "exception")
+	@AfterThrowing(value = "allPointcut()", throwing = "exception")
 	public void exceptionHandle(JoinPoint joinPoint, BaseException exception) {
 		MethodSignature signature = (MethodSignature)joinPoint.getSignature();
 

--- a/src/main/java/idorm/idormServer/common/performance/JpaInspector.java
+++ b/src/main/java/idorm/idormServer/common/performance/JpaInspector.java
@@ -1,0 +1,46 @@
+package idorm.idormServer.common.performance;
+
+import java.util.ArrayList;
+import java.util.Objects;
+
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Profile("local")
+@Slf4j
+@Component
+public class JpaInspector implements StatementInspector {
+
+	private static final ThreadLocal<QueryCounter> queryCounters = new ThreadLocal<>();
+
+	void start() {
+		queryCounters.set(new QueryCounter(0, System.currentTimeMillis(), new ArrayList<>()));
+	}
+
+	void clear() {
+		queryCounters.remove();
+	}
+
+	@Override
+	public String inspect(final String sql) {
+		log.info("sql = " + sql);
+		QueryCounter queryCounter = queryCounters.get();
+		if (Objects.nonNull(queryCounter)) {
+			queryCounter.addQueryCounting(sql);
+		}
+		return sql;
+	}
+
+	public String getQueriesResult() {
+		QueryCounter queryCounter = queryCounters.get();
+		return "COUNT : " + queryCounter.getCount() + "\n" + queryCounter.getResult();
+	}
+
+	public long getDuration(final long currentTimeMillis) {
+		QueryCounter queryCounter = queryCounters.get();
+		return currentTimeMillis - queryCounter.getTime();
+	}
+}

--- a/src/main/java/idorm/idormServer/common/performance/NPlusOneWarning.java
+++ b/src/main/java/idorm/idormServer/common/performance/NPlusOneWarning.java
@@ -1,0 +1,39 @@
+package idorm.idormServer.common.performance;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class NPlusOneWarning {
+	private static final int WARNING_STANDARD_COUNT = 2;
+	private static final String WARNING_STANDARD_WARDING = "select";
+	private static final String WARNING_MESSAGE = "\n동일한 select 쿼리문이 2개 이상 발생합니다. \nN+1 문제 혹은 로직 개선이 필요해 보입니다.";
+	private static final String LINE_BREAK = "\n\n";
+
+	public static String getWarningMessage(List<String> sql) {
+		if (isWarning(sql)) {
+			return WARNING_MESSAGE + LINE_BREAK;
+		}
+		return LINE_BREAK;
+	}
+
+	private static boolean isWarning(List<String> sql) {
+		final Map<String, Integer> nPlusOneWaring = createNPlusOneWaring(sql);
+		for (Integer value : nPlusOneWaring.values()) {
+			if (value > WARNING_STANDARD_COUNT) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static Map<String, Integer> createNPlusOneWaring(final List<String> sqlQueries) {
+		final Map<String, Integer> nPlusOneWaring = new HashMap<>();
+		for (String query : sqlQueries) {
+			if (query.contains(WARNING_STANDARD_WARDING)) {
+				nPlusOneWaring.put(query, nPlusOneWaring.getOrDefault(query, 0) + 1);
+			}
+		}
+		return nPlusOneWaring;
+	}
+}

--- a/src/main/java/idorm/idormServer/common/performance/QueryCountInterceptor.java
+++ b/src/main/java/idorm/idormServer/common/performance/QueryCountInterceptor.java
@@ -1,0 +1,52 @@
+package idorm.idormServer.common.performance;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Profile("local")
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QueryCountInterceptor implements HandlerInterceptor {
+
+	private final JpaInspector jpaInspector;
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws
+		Exception {
+		jpaInspector.start();
+		return true;
+	}
+
+	@Override
+	public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler,
+		Exception ex) throws Exception {
+
+		if (isExceptionThrown(ex)) {
+			log.info("Exception : {}", ex.getMessage());
+			return;
+		}
+		long duration = jpaInspector.getDuration(System.currentTimeMillis());
+		String result = generateSqlQueriesResult(request, duration, jpaInspector.getQueriesResult());
+		jpaInspector.clear();
+		log.info("\n===========RESULT==========\n{}", result);
+	}
+
+	private boolean isExceptionThrown(final Exception ex) {
+		return ex != null;
+	}
+
+	private String generateSqlQueriesResult(final HttpServletRequest request, final long duration,
+		final String queryResult) {
+		String url = "URL: " + request.getMethod() + " " + request.getRequestURI() + "\n";
+		String time = "TIME: " + duration + "\n";
+		return url + time + queryResult;
+	}
+}

--- a/src/main/java/idorm/idormServer/common/performance/QueryCounter.java
+++ b/src/main/java/idorm/idormServer/common/performance/QueryCounter.java
@@ -1,0 +1,34 @@
+package idorm.idormServer.common.performance;
+
+import java.util.List;
+
+public class QueryCounter {
+
+	private final long time;
+	private List<String> queries;
+	private int count;
+
+	public QueryCounter(final int count, final long time, final List<String> queries) {
+		this.time = time;
+		this.queries = queries;
+		this.count = count;
+	}
+
+	public void addQueryCounting(String sql) {
+		queries.add(sql);
+		count++;
+	}
+
+	public String getResult() {
+		String result = String.join("\n", queries);
+		return result + NPlusOneWarning.getWarningMessage(queries);
+	}
+
+	public long getTime() {
+		return time;
+	}
+
+	public int getCount() {
+		return count;
+	}
+}

--- a/src/main/java/idorm/idormServer/common/performance/deprecated/ConnectionHandler.java
+++ b/src/main/java/idorm/idormServer/common/performance/deprecated/ConnectionHandler.java
@@ -1,0 +1,41 @@
+package idorm.idormServer.common.performance.deprecated;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ConnectionHandler implements InvocationHandler {
+
+	private final Object target;
+	private final QueryCounter counter;
+
+	@Override
+	public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+		countPrepareStatement(method);
+		logQueryCount(method);
+		return method.invoke(target, args);
+	}
+
+	private void logQueryCount(Method method) {
+		if (method.getName().equals("close")) {
+			warnTooManyQuery();
+			log.info("\n===================== QUERY COUNT = {} =====================", counter.getCount());
+		}
+	}
+
+	private void countPrepareStatement(Method method) {
+		if (method.getName().equals("prepareStatement")) {
+			counter.increase();
+		}
+	}
+
+	private void warnTooManyQuery() {
+		if (counter.isWarn()) {
+			log.warn("\n============================ TOO MANY QUERY ============================");
+		}
+	}
+}

--- a/src/main/java/idorm/idormServer/common/performance/deprecated/PerformanceAdvice.java
+++ b/src/main/java/idorm/idormServer/common/performance/deprecated/PerformanceAdvice.java
@@ -1,0 +1,43 @@
+package idorm.idormServer.common.performance.deprecated;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Aspect
+@RequiredArgsConstructor
+public class PerformanceAdvice {
+
+	private final ThreadLocal<QueryCounter> queryCounter = new ThreadLocal<>();
+
+	@Pointcut("execution(* javax.sql.DataSource.getConnection(..))")
+	public void performancePointcut() {
+	}
+
+	@Around("performancePointcut()")
+	public Object start(ProceedingJoinPoint point) throws Throwable {
+		final Connection connection = (Connection)point.proceed();
+		queryCounter.set(new QueryCounter());
+		final QueryCounter counter = this.queryCounter.get();
+
+		final Connection proxyConnection = getProxyConnection(connection, counter);
+		queryCounter.remove();
+		return proxyConnection;
+	}
+
+	private Connection getProxyConnection(Connection connection, QueryCounter counter) {
+		return (Connection)Proxy.newProxyInstance(
+			getClass().getClassLoader(),
+			new Class[] {Connection.class},
+			new ConnectionHandler(connection, counter)
+		);
+	}
+}

--- a/src/main/java/idorm/idormServer/common/performance/deprecated/QueryCounter.java
+++ b/src/main/java/idorm/idormServer/common/performance/deprecated/QueryCounter.java
@@ -1,0 +1,17 @@
+package idorm.idormServer.common.performance.deprecated;
+
+import lombok.Getter;
+
+@Getter
+public class QueryCounter {
+
+	private int count;
+
+	public void increase() {
+		count++;
+	}
+
+	public boolean isWarn() {
+		return count > 10;
+	}
+}


### PR DESCRIPTION
❗️ 이슈 번호
close #54 


📝 구현 내용
1. 쿼리 튜닝 목적의 '쿼리 카운터' 구현 방식에는 '하이버네이트의 StatementInspector 인터페이스를 이용하는 방법'과 '다이나믹 프록시를 활용하는 방법'이 있습니다. 두가지 방식은 각각 아래 경로에 구현했습니다. 

-  하이버네이트의 StatementInspector 인터페이스 방식:  idorm.idormServer.common.performance 경로
-  다이나믹 프록시 방식 : idorm.idormServer.common.performance.deprecated 경로

2. 첫 번째 방식인 하이버네이트 제공 기능을 사용하였고, 선택한 이유는 아래와 같습니다.

1번 방식의 StatementInspector 방식은 Hibernate를 사용하지 않는 쿼리인 경우에는 카운트에 포함되지 않는 문제가 있습니다. 만약 하이버네이트 이외의 구현체를 사용하거나 JdbcTemplate을 사용하는 경우와 같이 범용성 있는 쿼리 카운터를 구현하고 싶다면 2번 방식이 더 적합한 방식입니다.

하지만 현재 아이돔 프로젝트는 더이상 기획 수정 사항이 없으며 구현도 마무리 단계이기 때문에 1번 방식을 사용해도 크게 문제가 없을 것이라 판단했습니다. 2번 방식을 1번 방식처럼 쿼리나 API에 대한 추가적인 것들을 출력하고 싶다면, 다이나믹 프록시를 한번 더 적용하는 방법 등을 고려해야하므로 구현에 좀 더 편리한 1번 방식을 채택하였습니다.

🙇🏻‍♂️ 리뷰어에게 부탁합니다!


💡 참고 자료